### PR TITLE
refactor: change three map using unit, remove whitelist contract/method

### DIFF
--- a/contracts/CCMMultisigWallet.scilla
+++ b/contracts/CCMMultisigWallet.scilla
@@ -91,12 +91,18 @@ type CalleeTransaction =
 | UpdateAdmin of ByStr20
 (* ClaimAdmin() *)
 | ClaimAdmin
-(* PopulateWhiteListFromContract(addr: ByStr20, val: Bool) *)
-| PopulateWhiteListFromContract of ByStr20 Bool
-(* PopulateWhiteListToContract(addr: ByStr20, val: Bool) *)
-| PopulateWhiteListToContract of ByStr20 Bool
-(* PopulateWhiteListMethod(method: String, val: Bool) *)
-| PopulateWhiteListMethod of String Bool
+(* PopulateWhiteListFromContract(addr: ByStr20) *)
+| PopulateWhiteListFromContract of ByStr20
+(* DeleteWhiteListFromContract(addr: ByStr20)*)
+| DeleteWhiteListFromContract of ByStr20
+(* PopulateWhiteListToContract(addr: ByStr20) *)
+| PopulateWhiteListToContract of ByStr20
+(* DeleteWhiteListToContract(addr: ByStr20)*)
+| DeleteWhiteListToContract of ByStr20
+(* PopulateWhiteListMethod(method: String) *)
+| PopulateWhiteListMethod of String
+(* DeleteWhiteListMethod(method: String) *)
+| DeleteWhiteListMethod of ByStr20
 (* PopulateConKeepersPublicKeyList(keepers: List ByStr20) *)
 | PopulateConKeepersPublicKeyList of (List ByStr20)
 (* PopulateCurEpochStartHeight(height: Uint32) *)
@@ -187,53 +193,68 @@ let custom_transaction_msg_as_list =
         {_recipient: calleeContract;
          _tag: "ClaimAdmin";
          _amount: Uint128 0}
-        (* PopulateWhiteListFromContract(addr: ByStr20, val: Bool) *)
-      | PopulateWhiteListFromContract addr val =>
+        (* PopulateWhiteListFromContract(addr: ByStr20) *)
+      | PopulateWhiteListFromContract addr =>
         {_recipient: calleeContract;
          _tag: "PopulateWhiteListFromContract";
          _amount: Uint128 0;
-         addr: addr;
-         val: val}
-      (* PopulateWhiteListToContract(addr: ByStr20, val: Bool) *)
-      | PopulateWhiteListToContract addr val =>
+         addr: addr}
+        (* DeleteWhiteListFromContract(addr: ByStr20) *) 
+      | DeleteWhiteListFromContract addr =>
+        {_recipient: calleeContract;
+        _tag: "DeleteWhiteListFromContract";
+        _amount: Uint128 0;
+        addr: addr}
+        (* PopulateWhiteListToContract(addr: ByStr20) *)
+      | PopulateWhiteListToContract addr =>
         {_recipient: calleeContract;
          _tag: "PopulateWhiteListToContract";
          _amount: Uint128 0;
-         addr: addr;
-         val: val}
-      (* PopulateWhiteListMethod(method: String, val: Bool) *)
-      | PopulateWhiteListMethod method val =>
+         addr: addr}
+        (* DeleteWhiteListToContract(addr: ByStr20)*)
+      | DeleteWhiteListToContract addr =>
+        {_recipient: calleeContract;
+         _tag: "DeleteWhiteListToContract";
+         _amount: Uint128 0;
+         addr: addr}
+        (* PopulateWhiteListMethod(method: String) *)
+      | PopulateWhiteListMethod method =>
         {_recipient: calleeContract;
          _tag: "PopulateWhiteListMethod";
          _amount: Uint128 0;
-         method: method;
-         val: val}
-      (* PopulateConKeepersPublicKeyList(keepers: List ByStr20) *)
+         method: method}
+        (* DeleteWhiteListMethod(method: String) *)
+      | DeleteWhiteListMethod method =>
+        {_recipient: calleeContract;
+        _tag: "DeleteWhiteListMethod";
+        _amount: Uint128 0;
+        method: method}
+        (* PopulateConKeepersPublicKeyList(keepers: List ByStr20) *)
       | PopulateConKeepersPublicKeyList keepers =>
         {_recipient: calleeContract;
          _tag: "PopulateConKeepersPublicKeyList";
          _amount: Uint128 0;
          keepers: keepers}
-      (* PopulateCurEpochStartHeight(height: Uint32) *)
+        (* PopulateCurEpochStartHeight(height: Uint32) *)
       | PopulateCurEpochStartHeight height =>
         {_recipient: calleeContract;
          _tag: "PopulateCurEpochStartHeight";
          _amount: Uint128 0;
          height: height}
-      (* PopulateZilToPolyTxHashMap(index: Uint256, val: ByStr32) *)
+        (* PopulateZilToPolyTxHashMap(index: Uint256, val: ByStr32) *)
       | PopulateZilToPolyTxHashMap index val =>
         {_recipient: calleeContract;
          _tag: "PopulateZilToPolyTxHashMap";
          _amount: Uint128 0;
          index: index;
          val: val}
-      (* PopulateZilToPolyTxHashIndex(index: Uint256) *)
+        (* PopulateZilToPolyTxHashIndex(index: Uint256) *)
       | PopulateZilToPolyTxHashIndex index =>
         {_recipient: calleeContract;
          _tag: "PopulateZilToPolyTxHashIndex";
          _amount: Uint128 0;
          index: index}
-      (* PopulateFromChainTxExist(chainId: Uint64, txId: ByStr32)*)
+        (* PopulateFromChainTxExist(chainId: Uint64, txId: ByStr32)*)
       | PopulateFromChainTxExist chainId txId =>
         {_recipient: calleeContract;
          _tag: "PopulateFromChainTxExist";
@@ -485,19 +506,33 @@ transition SubmitCustomClaimAdminTransaction(calleeContract: ByStr20)
   SubmitCustomTransaction calleeContract transaction
 end
 
-transition SubmitCustomPopulateWhiteListFromContractTransaction(calleeContract: ByStr20, addr: ByStr20, val: Bool)
-  transaction = PopulateWhiteListFromContract addr val;
+transition SubmitCustomPopulateWhiteListFromContractTransaction(calleeContract: ByStr20, addr: ByStr20)
+  transaction = PopulateWhiteListFromContract addr;
   SubmitCustomTransaction calleeContract transaction
 end
 
-transition SubmitCustomPopulateWhiteListToContractTransaction(calleeContract: ByStr20, addr: ByStr20, val: Bool)
-  transaction = PopulateWhiteListToContract addr val;
+transition SubmitCustomDeleteWhiteListFromContractTransaction(calleeContract: ByStr20, addr: ByStr20)
+  transaction = DeleteWhiteListFromContract addr;
   SubmitCustomTransaction calleeContract transaction
 end
 
+transition SubmitCustomPopulateWhiteListToContractTransaction(calleeContract: ByStr20, addr: ByStr20)
+  transaction = PopulateWhiteListToContract addr;
+  SubmitCustomTransaction calleeContract transaction
+end
 
-transition SubmitCustomPopulateWhiteListMethodTransaction(calleeContract: ByStr20, method: String, val: Bool)
-  transaction = PopulateWhiteListMethod method val;
+transition SubmitCustomDeleteWhiteListToContractTransaction(calleeContract: ByStr20, addr: ByStr20)
+  transaction = DeleteWhiteListToContract addr;
+  SubmitCustomTransaction calleeContract transaction
+end
+
+transition SubmitCustomPopulateWhiteListMethodTransaction(calleeContract: ByStr20, method: String)
+  transaction = PopulateWhiteListMethod method;
+  SubmitCustomTransaction calleeContract transaction
+end
+
+transition SubmitCustomDeleteWhiteListMethodTransaction(calleeContract: ByStr20, addr: ByStr20)
+  transaction = DeleteWhiteListMethod addr;
   SubmitCustomTransaction calleeContract transaction
 end
 

--- a/contracts/ZilCrossChainManager.scilla
+++ b/contracts/ZilCrossChainManager.scilla
@@ -13,6 +13,7 @@ let one_msg =
 
 let bool_active = True
 let bool_inactive = False
+let unit = Unit
 
 
 type Error =
@@ -94,9 +95,9 @@ field zilToPolyTxHashIndex: Uint256 = Uint256 0
 field fromChainTxExist : Map Uint64 (Map ByStr32 Unit) = Emp Uint64 (Map ByStr32 Unit)
 field contractadmin: ByStr20  = init_admin
 field stagingcontractadmin: Option ByStr20 = None {ByStr20}
-field whiteListFromContract: Map ByStr20 Bool = Emp ByStr20 Bool
-field whiteListToContract: Map ByStr20 Bool = Emp ByStr20 Bool
-field whiteListMethod: Map String Bool = Emp String Bool
+field whiteListFromContract: Map ByStr20 Unit = Emp ByStr20 Unit
+field whiteListToContract: Map ByStr20 Unit = Emp ByStr20 Unit
+field whiteListMethod: Map String Unit = Emp String Unit
 
 (* Procedures *)
 
@@ -157,12 +158,6 @@ procedure validToContract(addr: ByStr20)
   val_opt <- whiteListToContract[addr];
   match val_opt with
   | Some val =>
-    match val with
-    | True =>
-    | False =>
-      e = InvalidToContract;
-      ThrowError e
-    end
   | None => 
     e = InvalidToContract;
     ThrowError e
@@ -173,12 +168,6 @@ procedure validMethod(method: String)
   val_opt <- whiteListMethod[method];
   match val_opt with
   | Some val =>
-    match val with
-    | True =>
-    | False =>
-      e = InvalidMethod;
-      ThrowError e
-    end
   | None => 
     e = InvalidMethod;
     ThrowError e
@@ -251,12 +240,6 @@ procedure validFromContract(addr: ByStr20)
   val_opt <- whiteListFromContract[addr];
   match val_opt with
   | Some val =>
-    match val with
-    | True =>
-    | False =>
-      e = InvalidFromContract;
-      ThrowError e
-    end
   | None => 
     e = InvalidFromContract;
     ThrowError e
@@ -536,22 +519,40 @@ transition VerifyHeaderAndExecuteTx(proof: Proof, rawHeader: ByStr, headerProof:
 end
 
 
-transition PopulateWhiteListFromContract(addr: ByStr20, val: Bool, initiator: ByStr20)
+transition PopulateWhiteListFromContract(addr: ByStr20, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
-  whiteListFromContract[addr] := val
+  whiteListFromContract[addr] := unit
 end
 
-transition PopulateWhiteListToContract(addr: ByStr20, val: Bool, initiator: ByStr20)
+transition DeleteWhiteListFromContract(addr: ByStr20, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
-  whiteListToContract[addr] := val
+  delete whiteListFromContract[addr]
 end
 
-transition PopulateWhiteListMethod(method: String, val: Bool, initiator: ByStr20)
+transition PopulateWhiteListToContract(addr: ByStr20, initiator: ByStr20)
   IsProxy;
   IsAdmin initiator;
-  whiteListMethod[method] := val
+  whiteListToContract[addr] := unit
+end
+
+transition DeleteWhiteListToContract(addr: ByStr20, initiator: ByStr20)
+  IsProxy;
+  IsAdmin initiator;
+  delete whiteListToContract[addr]
+end
+
+transition PopulateWhiteListMethod(method: String, initiator: ByStr20)
+  IsProxy;
+  IsAdmin initiator;
+  whiteListMethod[method] := unit
+end
+
+transition DeleteWhiteListMethod(method: String, initiator: ByStr20)
+  IsProxy;
+  IsAdmin initiator;
+  delete whiteListMethod[method]
 end
 
 transition PopulateConKeepersPublicKeyList(keepers: List ByStr20, initiator: ByStr20)

--- a/contracts/ZilCrossChainManager.scilla
+++ b/contracts/ZilCrossChainManager.scilla
@@ -13,8 +13,6 @@ let one_msg =
 
 let bool_active = True
 let bool_inactive = False
-let unit = Unit
-
 
 type Error =
   | ContractFrozenFailure

--- a/contracts/ZilCrossChainManagerProxy.scilla
+++ b/contracts/ZilCrossChainManagerProxy.scilla
@@ -144,23 +144,44 @@ transition VerifyHeaderAndExecuteTx(proof: Proof, rawHeader: ByStr, headerProof:
   send msgs
 end
 
-transition PopulateWhiteListFromContract(addr: ByStr20, val: Bool)
+transition PopulateWhiteListFromContract(addr: ByStr20)
   current_impl <- crosschain_manager;
-  msg = {_tag: "PopulateWhiteListFromContract"; _recipient: current_impl; _amount: zero; addr: addr; val: val; initiator: _sender};
+  msg = {_tag: "PopulateWhiteListFromContract"; _recipient: current_impl; _amount: zero; addr: addr; initiator: _sender};
   msgs = one_msg msg;
   send msgs
 end
 
-transition PopulateWhiteListToContract(addr: ByStr20, val: Bool)
+transition DeleteWhiteListFromContract(addr: ByStr20)
   current_impl <- crosschain_manager;
-  msg = {_tag: "PopulateWhiteListToContract"; _recipient: current_impl; _amount: zero; addr: addr; val: val; initiator: _sender};
+  msg = {_tag: "DeleteWhiteListFromContract"; _recipient: current_impl; _amount: zero; addr: addr; initiator: _sender};
   msgs = one_msg msg;
   send msgs
 end
 
-transition PopulateWhiteListMethod(method: String, val: Bool)
+transition PopulateWhiteListToContract(addr: ByStr20)
   current_impl <- crosschain_manager;
-  msg = {_tag: "PopulateWhiteListMethod"; _recipient: current_impl; _amount: zero; method: method; val: val; initiator: _sender};
+  msg = {_tag: "PopulateWhiteListToContract"; _recipient: current_impl; _amount: zero; addr: addr; initiator: _sender};
+  msgs = one_msg msg;
+  send msgs
+end
+
+transition DeleteWhiteListToContract(addr: ByStr20)
+  current_impl <- crosschain_manager;
+  msg = {_tag: "DeleteWhiteListToContract"; _recipient: current_impl; _amount: zero; addr: addr; initiator: _sender};
+  msgs = one_msg msg;
+  send msgs
+end
+
+transition PopulateWhiteListMethod(method: String)
+  current_impl <- crosschain_manager;
+  msg = {_tag: "PopulateWhiteListMethod"; _recipient: current_impl; _amount: zero; method: method; initiator: _sender};
+  msgs = one_msg msg;
+  send msgs
+end
+
+transition DeleteWhiteListMethod(addr: ByStr20)
+  current_impl <- crosschain_manager;
+  msg = {_tag: "DeleteWhiteListMethod"; _recipient: current_impl; _amount: zero; addr: addr; initiator: _sender};
   msgs = one_msg msg;
   send msgs
 end


### PR DESCRIPTION
This PR introduces follow changes:

1. Change type of `whiteListFromContract`,`whiteListToContract` to `Map ByStr20 Unit` for reducing some storage memory.
2. Similar as 1, change `whiteListMethod`'s type to `Map String Unit`.
3. Add three delete transitions: `DeleteWhiteListFromContract`, `DeleteWhiteListToContract` and `DeleteWhiteListMethod`.
4. Refactor ccm proxy and multisig accordingly. 